### PR TITLE
Demote endpoint now requires 2 admins in userprofiles to work, #28

### DIFF
--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -100,7 +100,7 @@ public class UserProfileController : ControllerBase
             .SingleOrDefault(ur =>
                 ur.RoleId == role.Id &&
                 ur.UserId == id);
-
+        //if (_dbContext.UserRoles.Where(ur => ur.RoleId == role.Id))
         _dbContext.UserRoles.Remove(userRole);
         _dbContext.SaveChanges();
         return NoContent();
@@ -155,9 +155,10 @@ public class UserProfileController : ControllerBase
         matching.LastName = userProfile.LastName;
         matching.Email = userProfile.Email;
         matching.UserName = userProfile.UserName;
+        _dbContext.SaveChanges();
         return NoContent();   
     }
-    
+
     [Authorize(Roles = "Admin")]
     [HttpPut("deactivate/{id}")]
     public IActionResult DeactivateUser(int id)

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -155,8 +155,9 @@ public class UserProfileController : ControllerBase
         matching.LastName = userProfile.LastName;
         matching.Email = userProfile.Email;
         matching.UserName = userProfile.UserName;
-        
+        return NoContent();   
     }
+    
     [Authorize(Roles = "Admin")]
     [HttpPut("deactivate/{id}")]
     public IActionResult DeactivateUser(int id)

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -100,10 +100,13 @@ public class UserProfileController : ControllerBase
             .SingleOrDefault(ur =>
                 ur.RoleId == role.Id &&
                 ur.UserId == id);
-        //if (_dbContext.UserRoles.Where(ur => ur.RoleId == role.Id))
-        _dbContext.UserRoles.Remove(userRole);
-        _dbContext.SaveChanges();
-        return NoContent();
+        if (_dbContext.UserRoles.Where(ur => ur.RoleId == role.Id).Count() > 1){
+            _dbContext.UserRoles.Remove(userRole);
+            _dbContext.SaveChanges();
+            return NoContent();
+        }
+        return StatusCode(418, "You're the only admin left!");
+        
     }
 
     [Authorize]

--- a/client/src/components/userprofiles/UserProfileEdit.js
+++ b/client/src/components/userprofiles/UserProfileEdit.js
@@ -15,12 +15,12 @@ export const UserProfileEdit = () => {
 
     const promoteUserClick = (evt) => {
         evt.preventDefault()
-        promoteProfile(parseInt(id)).then(render())
+        promoteProfile(user.identityUserId).then(render())
     }
 
     const demoteUserClick = (evt) => {
         evt.preventDefault()
-        demoteProfile(parseInt(id))
+        demoteProfile(user.identityUserId)
         .catch(Window.Alert("You're the only admin left!"))
         .then(render())
         

--- a/client/src/components/userprofiles/UserProfileEdit.js
+++ b/client/src/components/userprofiles/UserProfileEdit.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { demoteProfile, editProfile, getProfileAndRoles, promoteProfile } from "../../managers/userProfileManager"
-import { Button } from "reactstrap"
+import { Alert, Button } from "reactstrap"
 
 
 export const UserProfileEdit = () => {
@@ -21,6 +21,7 @@ export const UserProfileEdit = () => {
     const demoteUserClick = (evt) => {
         evt.preventDefault()
         demoteProfile(parseInt(id)).then(render())
+        .catch(Window.Alert("You're the only admin left!"))
     }
 
     const handleSave = (evt) => {

--- a/client/src/components/userprofiles/UserProfileEdit.js
+++ b/client/src/components/userprofiles/UserProfileEdit.js
@@ -20,8 +20,10 @@ export const UserProfileEdit = () => {
 
     const demoteUserClick = (evt) => {
         evt.preventDefault()
-        demoteProfile(parseInt(id)).then(render())
+        demoteProfile(parseInt(id))
         .catch(Window.Alert("You're the only admin left!"))
+        .then(render())
+        
     }
 
     const handleSave = (evt) => {

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -18,11 +18,17 @@ export const getProfileAndRoles = (id) => {
 };
 
 export const promoteProfile = (id) => {
-  return fetch(`${_apiUrl}/promote/${id}`).then((res)=> res.json())
+  return fetch(`${_apiUrl}/promote/${id}`,  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  }).then((res)=> res.json())
 }
 
 export const demoteProfile = (id) => {
-  return fetch(`${_apiUrl}/demote/${id}`).then((res) => {
+  return fetch(`${_apiUrl}/demote/${id}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  }).then((res) => {
     if (res.ok) {
       return res.json()
     } else {

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -22,7 +22,15 @@ export const promoteProfile = (id) => {
 }
 
 export const demoteProfile = (id) => {
-  return fetch(`${_apiUrl}/demote/${id}`).then((res) => res.json());
+  return fetch(`${_apiUrl}/demote/${id}`).then((res) => {
+    if (res.ok) {
+      return res.json()
+    } else {
+      return res.text().then(error => {
+        throw new Error(error)
+      })
+    }
+  });
 }
 
 export const editProfile = (profile) => {


### PR DESCRIPTION
Changed demote endpoint to check for more than 1 admin in user profiles, demote can now return no content or a custom status with an error message. Toggle admin button checks for response and will catch the custom status and return a window alert before rerender.